### PR TITLE
fix: client reference prepare destination on ssr

### DIFF
--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,8 +1,14 @@
+import * as React from "react"
+
 export default function About() {
+  // verify this is client component
+  const [count, setCount] = React.useState(0);
+
   return (
     <main>
       <h1>About</h1>
       <p>This is the about page.</p>
+      <button onClick={() => setCount(c => c + 1)}>Count: {count}</button>
     </main>
   );
 }

--- a/packages/resolver/src/entry.ssr.tsx
+++ b/packages/resolver/src/entry.ssr.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "react" assert { env: "react-client" };
 import { createRequestListener } from "@mjackson/node-fetch-server";
 import express from "express";
 // @ts-expect-error - no types
@@ -11,6 +11,7 @@ import {
 import { createFromReadableStream } from "react-server-dom-parcel/client.edge" assert { env: "react-client" };
 
 import { callServer } from "./entry.rsc.ts" assert { env: "react-server" };
+import type { ServerPayload } from "react-router/rsc";
 
 const app = express();
 
@@ -18,13 +19,24 @@ app.use("/client", express.static("dist/client"));
 
 app.use(
   createRequestListener(async (request) => {
+    // rsc decoding (flight client) needs to be triggered inside fizz context (ssr)
+    // so that `ReactDOM.preinit/preloadModule` (aka prepare destination) can hoist client reference scripts.
+    let payload: Promise<ServerPayload>;
+    function SsrRoot(props: { getPayload: () => Promise<ServerPayload> }) {
+      payload ??= props.getPayload();
+      return <RSCStaticRouter payload={React.use(payload) as any} />;
+    }
+
     return routeRSCServerRequest(
       request,
       callServer,
-      createFromReadableStream,
+      // hack to delay `decode`` inside `renderHTML`
+      // https://github.com/remix-run/react-router/blob/692ce42b6c7d1e2d7ddc43213585154fc1dfeabc/packages/react-router/lib/rsc/server.ssr.tsx#L54-L65
+      // @ts-ignore
+      (body) => () => createFromReadableStream(body),
       async (payload) => {
         return await renderHTMLToReadableStream(
-          React.createElement(RSCStaticRouter, { payload }),
+          React.createElement(SsrRoot, { getPayload: payload as any }),
           {
             bootstrapScriptContent: (
               callServer as unknown as { bootstrapScript: string }


### PR DESCRIPTION
Hello! This is related to client reference preinit/preload we've been talking. For SSR prepare destination (which Parcel correctly implements), `(react-server-dom-xxx/client).createFromReadableStream` needs to be triggered inside `(react-dom/server).renderToReadableStream`. There was a conversation on `react-server-dom-parcel` PR https://github.com/facebook/react/pull/31799#discussion_r1886166075

I just hacked around `decode` and `renderHtml` to verify this, but this probably means react router side needs to adjust how `routeRSCServerRequest` works. This feels like React side limitation, so probably they might find a way to avoid this gotcha, but just sharing it here in case you find it useful.

Also I verified it on my Vite plugin example with the same hack https://github.com/hi-ogawa/vite-plugins/pull/765 (but note that, in my case with `react-server-dom-webpack`, I'm not using builtin `chunks` system, but rather calling `ReactDOM.preloadModule` manually during `__webpack_require__` https://github.com/hi-ogawa/vite-plugins/blob/2bf1040130352cab6ce6d47107fbd477637b8447/packages/rsc/src/ssr.ts#L11-L39).

## How to verify

```sh
curl http://localhost:3000/about
```

- before

```html
<head>
  <meta charSet="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>React Router Parcel</title>
</head>
```

- after

```html
<head>
  <meta charSet="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <script src="/client/server.8e6eebd4.js" type="module" async=""></script>
  <script src="/client/root.8bb36921.js" type="module" async=""></script>
  <script src="/client/about.a4f2d2cb.js" type="module" async=""></script>
  <title>React Router Parcel</title>
</head>
```