### PR TITLE
fix: pass props to route client components

### DIFF
--- a/packages/resolver/src/empty.ts
+++ b/packages/resolver/src/empty.ts
@@ -1,0 +1,2 @@
+// This file is intended to be the `filePath` for virtual modules
+export {};

--- a/packages/resolver/tsup.config.ts
+++ b/packages/resolver/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       fsp.copyFile("src/entry.browser.tsx", "./dist/entry.browser.tsx"),
       fsp.copyFile("src/entry.rsc.ts", "./dist/entry.rsc.ts"),
       fsp.copyFile("src/entry.ssr.tsx", "./dist/entry.ssr.tsx"),
+      fsp.copyFile("src/empty.ts", "./dist/empty.ts"),
     ]);
   },
 });


### PR DESCRIPTION
The existing `?client-route-module` virtual module has been renamed to `?client-route-module-source` to indicate that it's more of a straight wrapper around the source file. Now, `?client-route-module` is the place for any wrappers we need around the source code. Any existing references to `?client-route-module` now get the wrapped version of all components where props are passed in.