### PR TITLE
fix: update babel dependencies

### DIFF
--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -21,10 +21,10 @@
     "react-router": "*"
   },
   "dependencies": {
-    "@babel/core": "^7.26.10",
-    "@babel/generator": "^7.27.0",
-    "@babel/parser": "^7.27.0",
-    "@babel/traverse": "^7.27.0",
+    "@babel/core": "^7.27.1",
+    "@babel/generator": "^7.27.1",
+    "@babel/parser": "^7.27.2",
+    "@babel/traverse": "^7.27.1",
     "@babel/types": "^7.27.1",
     "@parcel/plugin": "^2.15.0",
     "babel-dead-code-elimination": "^1.0.10",

--- a/packages/transformer/src/babel/babel.ts
+++ b/packages/transformer/src/babel/babel.ts
@@ -1,13 +1,7 @@
-import type { NodePath } from "@babel/traverse";
-import type { types as Babel } from "@babel/core";
-import { parse, type ParseResult } from "@babel/parser";
-
-// These `require`s were needed to support building within vite-ecosystem-ci,
-// otherwise we get errors that `traverse` and `generate` are not functions.
-const traverse = require("@babel/traverse")
-  .default as typeof import("@babel/traverse").default;
-const generate = require("@babel/generator")
-  .default as typeof import("@babel/generator").default;
-
-export { traverse, generate, parse };
-export type { Babel, NodePath, ParseResult };
+export type { NodePath, Node } from "@babel/traverse";
+export type { types } from "@babel/core";
+export { parse, type ParseResult } from "@babel/parser";
+export { default as traverse } from "@babel/traverse";
+export { default as generate } from "@babel/generator";
+export type { File } from "@babel/types";
+export { cloneNode } from "@babel/types"

--- a/packages/transformer/src/babel/remove-exports.ts
+++ b/packages/transformer/src/babel/remove-exports.ts
@@ -3,18 +3,17 @@ import {
   deadCodeElimination,
 } from "babel-dead-code-elimination";
 
-import type { Babel, NodePath, ParseResult } from "./babel.ts";
-import { traverse } from "./babel.ts";
+import * as babel from "./babel.ts";
 
 export const removeExports = (
-  ast: ParseResult<Babel.File>,
+  ast: babel.ParseResult<babel.File>,
   exportsToRemove: string[]
 ) => {
   let previouslyReferencedIdentifiers = findReferencedIdentifiers(ast);
   let exportsFiltered = false;
-  let markedForRemoval = new Set<NodePath<Babel.Node>>();
+  let markedForRemoval = new Set<babel.NodePath<babel.Node>>();
 
-  traverse(ast, {
+  babel.traverse(ast, {
     ExportDeclaration(path) {
       // export { foo };
       // export { bar } from "./module";
@@ -115,7 +114,7 @@ export const removeExports = (
 };
 
 function validateDestructuredExports(
-  id: Babel.ArrayPattern | Babel.ObjectPattern,
+  id: babel.types.ArrayPattern | babel.types.ObjectPattern,
   exportsToRemove: string[]
 ) {
   if (id.type === "ArrayPattern") {

--- a/packages/transformer/src/transformer.ts
+++ b/packages/transformer/src/transformer.ts
@@ -3,8 +3,7 @@ import oxcTransform from "oxc-transform";
 import { Transformer } from "@parcel/plugin";
 import type { TransformerResult, MutableAsset } from "@parcel/types";
 
-import { generate, parse } from "./babel/babel.ts";
-import { cloneNode } from "@babel/types"
+import * as babel from "./babel/babel.ts";
 import { removeExports } from "./babel/remove-exports.ts";
 
 const SERVER_ONLY_ROUTE_EXPORTS = [
@@ -65,7 +64,7 @@ export default new Transformer({
     // TODO: Add sourcemaps.....
     // TODO: Maybe pass TSConfig in here?
     const transformed = oxcTransform.transform(asset.filePath, routeSource);
-    const ast = parse(transformed.code, {
+    const ast = babel.parse(transformed.code, {
       sourceType: "module",
     });
 
@@ -110,10 +109,10 @@ export default new Transformer({
         ? [...SERVER_ONLY_ROUTE_EXPORTS, ...COMPONENT_EXPORTS]
         : SERVER_ONLY_ROUTE_EXPORTS;
 
-      let clientRouteModuleAst = cloneNode(ast, true);
+      let clientRouteModuleAst = babel.cloneNode(ast, true);
       removeExports(clientRouteModuleAst, exportsToRemove);
 
-      let clientRouteModuleSource = '"use client";\n' + generate(clientRouteModuleAst).code;
+      let clientRouteModuleSource = '"use client";\n' + babel.generate(clientRouteModuleAst).code;
       assets.push({
         uniqueKey: 'client-route-module-source',
         type: 'jsx',
@@ -127,13 +126,13 @@ export default new Transformer({
       }
 
       // server route module
-      let serverRouteModuleAst = cloneNode(ast, true);
+      let serverRouteModuleAst = babel.cloneNode(ast, true);
       removeExports(
         serverRouteModuleAst,
         isServerFirstRoute ? CLIENT_NON_COMPONENT_EXPORTS : CLIENT_ROUTE_EXPORTS
       );
 
-      let serverRouteModule = generate(serverRouteModuleAst).code;
+      let serverRouteModule = babel.generate(serverRouteModuleAst).code;
       if (!isServerFirstRoute) {
         for (const staticExport of staticExports) {
           if (CLIENT_NON_COMPONENT_EXPORTS_SET.has(staticExport)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,12 +19,26 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
+"@babel/code-frame@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.26.8":
   version "7.26.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
-"@babel/core@^7.21.8", "@babel/core@^7.23.7", "@babel/core@^7.26.10":
+"@babel/compat-data@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.2.tgz#4183f9e642fd84e74e3eea7ffa93a412e3b102c9"
+  integrity sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==
+
+"@babel/core@^7.21.8", "@babel/core@^7.23.7":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.10.tgz#5c876f83c8c4dcb233ee4b670c0606f2ac3000f9"
   integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
@@ -45,6 +59,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.1.tgz#89de51e86bd12246003e3524704c49541b16c3e6"
+  integrity sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/helper-compilation-targets" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.27.1"
+    "@babel/helpers" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.21.5", "@babel/generator@^7.26.10", "@babel/generator@^7.26.5", "@babel/generator@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.0.tgz#764382b5392e5b9aff93cadb190d0745866cbc2c"
@@ -52,6 +87,17 @@
   dependencies:
     "@babel/parser" "^7.27.0"
     "@babel/types" "^7.27.0"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.1.tgz#862d4fad858f7208edd487c28b58144036b76230"
+  integrity sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==
+  dependencies:
+    "@babel/parser" "^7.27.1"
+    "@babel/types" "^7.27.1"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
@@ -70,6 +116,17 @@
   dependencies:
     "@babel/compat-data" "^7.26.8"
     "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.27.1":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
+  integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
+  dependencies:
+    "@babel/compat-data" "^7.27.2"
+    "@babel/helper-validator-option" "^7.27.1"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -103,6 +160,14 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/helper-module-imports@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz#7ef769a323e2655e126673bb6d2d6913bbead204"
+  integrity sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==
+  dependencies:
+    "@babel/traverse" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
 "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
@@ -111,6 +176,15 @@
     "@babel/helper-module-imports" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
+
+"@babel/helper-module-transforms@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz#e1663b8b71d2de948da5c4fb2a20ca4f3ec27a6f"
+  integrity sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@babel/traverse" "^7.27.1"
 
 "@babel/helper-optimise-call-expression@^7.25.9":
   version "7.25.9"
@@ -166,6 +240,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
   integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
 
+"@babel/helper-validator-option@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
+  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+
 "@babel/helpers@^7.26.10":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.0.tgz#53d156098defa8243eab0f32fa17589075a1b808"
@@ -174,12 +253,27 @@
     "@babel/template" "^7.27.0"
     "@babel/types" "^7.27.0"
 
+"@babel/helpers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.1.tgz#ffc27013038607cdba3288e692c3611c06a18aa4"
+  integrity sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==
+  dependencies:
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.21.8", "@babel/parser@^7.23.6", "@babel/parser@^7.26.10", "@babel/parser@^7.26.7", "@babel/parser@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.0.tgz#3d7d6ee268e41d2600091cbd4e145ffee85a44ec"
   integrity sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==
   dependencies:
     "@babel/types" "^7.27.0"
+
+"@babel/parser@^7.27.1", "@babel/parser@^7.27.2":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.2.tgz#577518bedb17a2ce4212afd052e01f7df0941127"
+  integrity sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==
+  dependencies:
+    "@babel/types" "^7.27.1"
 
 "@babel/plugin-syntax-decorators@^7.22.10":
   version "7.25.9"
@@ -241,6 +335,15 @@
     "@babel/parser" "^7.27.0"
     "@babel/types" "^7.27.0"
 
+"@babel/template@^7.27.1":
+  version "7.27.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
+  integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/parser" "^7.27.2"
+    "@babel/types" "^7.27.1"
+
 "@babel/traverse@^7.23.2", "@babel/traverse@^7.23.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.10", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.7", "@babel/traverse@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.0.tgz#11d7e644779e166c0442f9a07274d02cd91d4a70"
@@ -251,6 +354,19 @@
     "@babel/parser" "^7.27.0"
     "@babel/template" "^7.27.0"
     "@babel/types" "^7.27.0"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.1.tgz#4db772902b133bbddd1c4f7a7ee47761c1b9f291"
+  integrity sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.27.1"
+    "@babel/parser" "^7.27.1"
+    "@babel/template" "^7.27.1"
+    "@babel/types" "^7.27.1"
     debug "^4.3.1"
     globals "^11.1.0"
 


### PR DESCRIPTION
Our newly introduced use of Babel's `cloneNode` introduced type errors due to mismatched types across versions. Bumping to the latest of everything fixes this.