### PR TITLE
test: add Vitest for unit tests

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,19 @@
+name: Vitest Tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g yarn && yarn
+      - name: Run Vitest tests
+        run: yarn vitest

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "app:clean": "rm -rf dist .parcel-cache .react-router .react-router-parcel",
     "app:dev": "parcel",
     "app:start": "node ./dist/server/server.js",
-    "test": "playwright test"
+    "test": "yarn test:vitest run && yarn test:playwright",
+    "test:playwright": "playwright test",
+    "test:vitest": "vitest"
   },
   "targets": {
     "server": {
@@ -38,7 +40,8 @@
     "react-server-dom-parcel": "^19.1.0",
     "remix-utils": "^8.7.0",
     "server-only": "0.0.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
   },
   "workspaces": [
     "packages/*"

--- a/packages/transformer/src/babel/remove-exports.test.ts
+++ b/packages/transformer/src/babel/remove-exports.test.ts
@@ -1,0 +1,832 @@
+import { describe, test, expect } from "vitest";
+import { generate, parse } from "./babel";
+import { removeExports } from "./remove-exports";
+
+function transform(code: string, exportsToRemove: string[]) {
+  let ast = parse(code, { sourceType: "module" });
+  removeExports(ast, exportsToRemove);
+  return generate(ast);
+}
+
+describe("transform", () => {
+  test("arrow function", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = () => {}
+      export const serverExport_2 = () => {}
+
+      export const clientExport_1 = () => {}
+      export const clientExport_2 = () => {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = () => {};
+      export const clientExport_2 = () => {};"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("arrow function with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export const serverExport_1 = () => serverUtil()
+      export const serverExport_2 = () => serverUtil()
+
+      export const clientExport_1 = () => clientUtil()
+      export const clientExport_2 = () => clientUtil()
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = () => clientUtil();
+      export const clientExport_2 = () => clientUtil();"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("function statement", () => {
+    let result = transform(
+      `
+      export function serverExport_1(){}
+      export function serverExport_2(){}
+
+      export function clientExport_1(){}
+      export function clientExport_2(){}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export function clientExport_1() {}
+      export function clientExport_2() {}"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("function statement with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      function sharedUtil() { return sharedLib() }
+      function serverUtil() { return sharedUtil(serverLib(SERVER_STRING)) }
+      function clientUtil() { return sharedUtil(clientLib()) }
+
+      export function serverExport_1() { return serverUtil() }
+      export function serverExport_2() { return serverUtil() }
+
+      export function clientExport_1() { return clientUtil() }
+      export function clientExport_2() { return clientUtil() }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      function sharedUtil() {
+        return sharedLib();
+      }
+      function clientUtil() {
+        return sharedUtil(clientLib());
+      }
+      export function clientExport_1() {
+        return clientUtil();
+      }
+      export function clientExport_2() {
+        return clientUtil();
+      }"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("object", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = {}
+      export const serverExport_2 = {}
+
+      export const clientExport_1 = {}
+      export const clientExport_2 = {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = {};
+      export const clientExport_2 = {};"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("object with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export const serverExport_1 = { value: serverUtil() }
+      export const serverExport_2 = { value: serverUtil() }
+
+      export const clientExport_1 = { value: clientUtil() }
+      export const clientExport_2 = { value: clientUtil() }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = {
+        value: clientUtil()
+      };
+      export const clientExport_2 = {
+        value: clientUtil()
+      };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("class", () => {
+    let result = transform(
+      `
+      export class serverExport_1 {}
+      export class serverExport_2 {}
+
+      export class clientExport_1 {}
+      export class clientExport_2 {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export class clientExport_1 {}
+      export class clientExport_2 {}"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("class with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export class serverExport_1{
+        static util = serverUtil()
+      }
+      export class serverExport_2{
+        static util = serverUtil()
+      }
+
+      export class clientExport_1{
+        static util = clientUtil()
+      }
+      export class clientExport_2{
+        static util = clientUtil()
+      }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export class clientExport_1 {
+        static util = clientUtil();
+      }
+      export class clientExport_2 {
+        static util = clientUtil();
+      }"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("function call", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = globalFunction()
+      export const serverExport_2 = globalFunction()
+
+      export const clientExport_1 = globalFunction()
+      export const clientExport_2 = globalFunction()
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = globalFunction();
+      export const clientExport_2 = globalFunction();"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("function call with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export const serverExport_1 = serverUtil()
+      export const serverExport_2 = serverUtil()
+
+      export const clientExport_1 = clientUtil()
+      export const clientExport_2 = clientUtil()
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = clientUtil();
+      export const clientExport_2 = clientUtil();"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("iife", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = (() => {})()
+      export const serverExport_2 = (() => {})()
+
+      export const clientExport_1 = (() => {})()
+      export const clientExport_2 = (() => {})()
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = (() => {})();
+      export const clientExport_2 = (() => {})();"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("iife with dependencies", () => {
+    let result = transform(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export const serverExport_1 = (() => serverUtil())()
+      export const serverExport_2 = (() => serverUtil())()
+
+      export const clientExport_1 = (() => clientUtil())()
+      export const clientExport_2 = (() => clientUtil())()
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = (() => clientUtil())();
+      export const clientExport_2 = (() => clientUtil())();"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export", () => {
+    let result = transform(
+      `
+      const serverExport_1 = 123
+      const serverExport_2 = 123
+
+      const clientExport_1 = 123
+      const clientExport_2 = 123
+
+      export { serverExport_1 }
+      export { serverExport_2 }
+
+      export { clientExport_1 }
+      export { clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const clientExport_1 = 123;
+      const clientExport_2 = 123;
+      export { clientExport_1 };
+      export { clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export multiple", () => {
+    let result = transform(
+      `
+      const serverExport_1 = 123
+      const serverExport_2 = 123
+
+      const clientExport_1 = 123
+      const clientExport_2 = 123
+
+      export { serverExport_1, serverExport_2 }
+      export { clientExport_1, clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const clientExport_1 = 123;
+      const clientExport_2 = 123;
+      export { clientExport_1, clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export multiple mixed", () => {
+    let result = transform(
+      `
+      const removeMe_1 = 123
+      const removeMe_2 = 123
+
+      const keepMe_1 = 123
+      const keepMe_2 = 123
+
+      export { removeMe_1, keepMe_1 }
+      export { removeMe_2, keepMe_2 }
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const keepMe_1 = 123;
+      const keepMe_2 = 123;
+      export { keepMe_1 };
+      export { keepMe_2 };"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
+  });
+
+  test("re-export", () => {
+    let result = transform(
+      `
+      export { serverExport_1 } from './server/1'
+      export { serverExport_2 } from './server/2'
+
+      export { clientExport_1 } from './client/1'
+      export { clientExport_2 } from './client/2'
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export { clientExport_1 } from './client/1';
+      export { clientExport_2 } from './client/2';"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export multiple", () => {
+    let result = transform(
+      `
+      export { serverExport_1, serverExport_2 } from './server'
+      export { clientExport_1, clientExport_2 } from './client'
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(
+      "\"export { clientExport_1, clientExport_2 } from './client';\""
+    );
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export multiple mixed", () => {
+    let result = transform(
+      `
+      export { removeMe_1, keepMe_1 } from './1'
+      export { removeMe_2, keepMe_2 } from './2'
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export { keepMe_1 } from './1';
+      export { keepMe_2 } from './2';"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
+  });
+
+  test("re-export manual", () => {
+    let result = transform(
+      `
+      import { serverExport_1 } from './server/1'
+      import { serverExport_2 } from './server/2'
+      import { clientExport_1 } from './client/1'
+      import { clientExport_2 } from './client/2'
+
+      export { serverExport_1 }
+      export { serverExport_2 }
+
+      export { clientExport_1 }
+      export { clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientExport_1 } from './client/1';
+      import { clientExport_2 } from './client/2';
+      export { clientExport_1 };
+      export { clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export manual multiple", () => {
+    let result = transform(
+      `
+      import { serverExport_1, serverExport_2 } from './server'
+      import { clientExport_1, clientExport_2 } from './client'
+
+      export { serverExport_1, serverExport_2 }
+      export { clientExport_1, clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientExport_1, clientExport_2 } from './client';
+      export { clientExport_1, clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export manual multiple mixed", () => {
+    let result = transform(
+      `
+      import { removeMe_1, keepMe_1 } from './1'
+      import { removeMe_2, keepMe_2 } from './2'
+
+      export { removeMe_1, keepMe_1 }
+      export { removeMe_2, keepMe_2 }
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { keepMe_1 } from './1';
+      import { keepMe_2 } from './2';
+      export { keepMe_1 };
+      export { keepMe_2 };"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
+  });
+
+  test("number", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = 123
+      export const serverExport_2 = 123
+
+      export const clientExport_1 = 123
+      export const clientExport_2 = 123
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = 123;
+      export const clientExport_2 = 123;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("string", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = 'string'
+      export const serverExport_2 = 'string'
+
+      export const clientExport_1 = 'string'
+      export const clientExport_2 = 'string'
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = 'string';
+      export const clientExport_2 = 'string';"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("string reference", () => {
+    let result = transform(
+      `
+      const SERVER_STRING = 'SERVER_STRING';
+      const CLIENT_STRING = 'CLIENT_STRING';
+
+      export const serverExport_1 = SERVER_STRING
+      export const serverExport_2 = SERVER_STRING
+
+      export const clientExport_1 = CLIENT_STRING
+      export const clientExport_2 = CLIENT_STRING
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const CLIENT_STRING = 'CLIENT_STRING';
+      export const clientExport_1 = CLIENT_STRING;
+      export const clientExport_2 = CLIENT_STRING;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("null", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = null
+      export const serverExport_2 = null
+
+      export const clientExport_1 = null
+      export const clientExport_2 = null
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = null;
+      export const clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("multiple variable declarators", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = null,
+        serverExport_2 = null
+
+      export const clientExport_1 = null,
+        clientExport_2 = null
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = null,
+        clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("multiple variable declarators mixed", () => {
+    let result = transform(
+      `
+      export const serverExport_1 = null,
+        clientExport_1 = null
+
+      export const clientExport_2 = null,
+        serverExport_2 = null
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = null;
+      export const clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("array destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const [serverExport_1, serverExport_2] = [null, null]
+
+        export const [clientExport_1, clientExport_2] = [null, null]
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_1"]`
+    );
+  });
+
+  test("array rest destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const [...serverExport_1] = [null, null]
+
+        export const [clientExport_1, clientExport_2] = [null, null]
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_1"]`
+    );
+  });
+
+  test("nested array destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const [keepMe_1, [{ nested: [ { nested: [serverExport_2] } ] }] ] = nested;
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_2"]`
+    );
+  });
+
+  test("array destructuring works when nothing is removed", () => {
+    let result = transform(
+      `
+      export const [clientExport_1, clientExport_2] = [null, null]
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(
+      `"export const [clientExport_1, clientExport_2] = [null, null];"`
+    );
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("object destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const { serverExport_1, serverExport_2 } = {}
+
+        export const { clientExport_1, clientExport_2 } = {}
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_1"]`
+    );
+  });
+
+  test("object rest destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const { ...serverExport_1 } = {}
+
+        export const { ...clientExport_1 } = {}
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_1"]`
+    );
+  });
+
+  test("nested object destructuring throws on removed export", () => {
+    expect(() =>
+      transform(
+        `
+        export const [keepMe_1, [{ nested: [ { nested: { serverExport_2 } } ] }]] = nested;
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot remove destructured export "serverExport_2"]`
+    );
+  });
+
+  test("object destructuring works when nothing is removed", () => {
+    let result = transform(
+      `
+      export const { clientExport_1, clientExport_2 } = {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const {
+        clientExport_1,
+        clientExport_2
+      } = {};"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("default export", () => {
+    let result = transform(
+      `
+      export const keepMe = null;
+
+      const removeMe = null;
+
+      export default removeMe;
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default export aggregated", () => {
+    let result = transform(
+      `
+      export const keepMe = null;
+
+      const removeMe = null;
+
+      export { removeMe as default };
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default export aggregated mixed", () => {
+    let result = transform(
+      `
+      const keepMe = null;
+
+      const removeMe = null;
+
+      export { removeMe as default, keepMe };
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const keepMe = null;
+      export { keepMe };"
+    `);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default re-export", () => {
+    let result = transform(
+      `
+      export const keepMe = null;
+
+      export { default } from "./module";
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default re-export mixed", () => {
+    let result = transform(
+      `
+      export { default, keepMe } from "./module";
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(
+      `"export { keepMe } from "./module";"`
+    );
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("nothing removed", () => {
+    let result = transform(
+      `
+      export const clientExport_1 = () => {}
+      export const clientExport_2 = () => {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = () => {};
+      export const clientExport_2 = () => {};"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["packages/**/*.test.{ts,tsx}"],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -1874,7 +1874,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/estree@1.0.7":
+"@types/estree@1.0.7", "@types/estree@^1.0.0":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
@@ -1974,6 +1974,65 @@
     "@types/node" "*"
     "@types/send" "*"
 
+"@vitest/expect@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.4.tgz#837651a71682e3611c3df7b58b157ba485bd8029"
+  integrity sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==
+  dependencies:
+    "@vitest/spy" "3.1.4"
+    "@vitest/utils" "3.1.4"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.4.tgz#73441022b86c7299bfbd11a9fb2e99a7ddc2bb0e"
+  integrity sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==
+  dependencies:
+    "@vitest/spy" "3.1.4"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.1.4", "@vitest/pretty-format@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.4.tgz#da3e98c250cde3ce39fe8e709339814607b185e8"
+  integrity sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.4.tgz#19fa16eb397f5325b99baca48c2bca6cadd098fa"
+  integrity sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==
+  dependencies:
+    "@vitest/utils" "3.1.4"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.4.tgz#7897d4960a3cf617fb0f17e182cc15c7e3e4ed3f"
+  integrity sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==
+  dependencies:
+    "@vitest/pretty-format" "3.1.4"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.4.tgz#94bb566da7ef6deb7c4e1fd79b78f19aa5465b9f"
+  integrity sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.4.tgz#f9f20d92f1384a9d66548c480885390760047b5e"
+  integrity sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==
+  dependencies:
+    "@vitest/pretty-format" "3.1.4"
+    loupe "^3.1.3"
+    tinyrainbow "^2.0.0"
+
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
@@ -2026,6 +2085,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 babel-dead-code-elimination@^1.0.10, babel-dead-code-elimination@^1.0.6:
   version "1.0.10"
@@ -2164,6 +2228,17 @@ caniuse-lite@^1.0.30001716:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz#5d9fec5ce09796a1893013825510678928aca129"
   integrity sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==
 
+chai@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
+  integrity sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -2171,6 +2246,11 @@ chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 chokidar@^4.0.0, chokidar@^4.0.3:
   version "4.0.3"
@@ -2298,6 +2378,11 @@ dedent@^1.5.3:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.3.tgz#99aee19eb9bae55a67327717b6e848d0bf777e5a"
   integrity sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==
 
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 depd@2.0.0, depd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -2399,6 +2484,11 @@ es-module-lexer@^1.3.1, es-module-lexer@^1.5.4:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
   integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -2447,6 +2537,13 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
@@ -2474,6 +2571,11 @@ exit-hook@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-2.2.1.tgz#007b2d92c6428eda2b76e7016a34351586934593"
   integrity sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==
+
+expect-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.1.tgz#af76d8b357cf5fa76c41c09dafb79c549e75f71f"
+  integrity sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==
 
 express@^4.21.2:
   version "4.21.2"
@@ -2549,6 +2651,11 @@ fdir@^6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
+
+fdir@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
+  integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
 
 figures@^6.1.0:
   version "6.1.0"
@@ -2999,6 +3106,11 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loupe@^3.1.0, loupe@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
+  integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -3015,6 +3127,13 @@ lru-cache@^7.4.4, lru-cache@^7.5.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+magic-string@^0.30.17:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -3365,6 +3484,16 @@ pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -3758,6 +3887,11 @@ side-channel@^1.0.6, side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
@@ -3814,26 +3948,27 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz#6d6e980c9df2b6fc905343a3b2d702a6239536c3"
   integrity sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 statuses@2.0.1, statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+std-env@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 stream-slice@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/stream-slice/-/stream-slice-0.1.2.tgz#2dc4f4e1b936fb13f3eb39a2def1932798d07a4b"
   integrity sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3851,14 +3986,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3916,6 +4044,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
 tinyexec@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
@@ -3928,6 +4061,29 @@ tinyglobby@^0.2.11, tinyglobby@^0.2.12:
   dependencies:
     fdir "^6.4.3"
     picomatch "^4.0.2"
+
+tinyglobby@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
+  integrity sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==
+  dependencies:
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
+
+tinypool@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
+  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -4094,6 +4250,17 @@ vite-node@3.0.0-beta.2:
     pathe "^1.1.2"
     vite "^5.0.0 || ^6.0.0"
 
+vite-node@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.4.tgz#13f10b2cb155197a971cb2761664ec952c6cae18"
+  integrity sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.0"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0"
+
 "vite@^5.0.0 || ^6.0.0":
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.2.tgz#4c1bb01b1cea853686a191657bbc14272a038f0a"
@@ -4107,6 +4274,33 @@ vite-node@3.0.0-beta.2:
     tinyglobby "^0.2.12"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.4.tgz#5f495b7dbb1d4d208b88508cd4dfceb006f8b7e6"
+  integrity sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==
+  dependencies:
+    "@vitest/expect" "3.1.4"
+    "@vitest/mocker" "3.1.4"
+    "@vitest/pretty-format" "^3.1.4"
+    "@vitest/runner" "3.1.4"
+    "@vitest/snapshot" "3.1.4"
+    "@vitest/spy" "3.1.4"
+    "@vitest/utils" "3.1.4"
+    chai "^5.2.0"
+    debug "^4.4.0"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.13"
+    tinypool "^1.0.2"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0"
+    vite-node "3.1.4"
+    why-is-node-running "^2.3.0"
 
 weak-lru-cache@^1.2.2:
   version "1.2.2"
@@ -4140,6 +4334,14 @@ which@^3.0.0:
   integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
Since our code is written for bundling with tsup, I've added Vitest for running unit tests. As a first test, I've ported over the `remove-exports` test from React Router. It was originally written for Jest, but since Vite supports the same API, all I had to do was import all the previously global test functions.